### PR TITLE
ArgumentResolver가 @Member가 없는 메서드의 MemberDTO 파라미터에 값을 넣는 오류 수정 완료.

### DIFF
--- a/src/main/java/com/busanit501/travelproject/config/CustomMemberArgumentResolver.java
+++ b/src/main/java/com/busanit501/travelproject/config/CustomMemberArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.busanit501.travelproject.config;
 
+import com.busanit501.travelproject.annotation.member.Member;
 import com.busanit501.travelproject.context.MemberContext;
 import com.busanit501.travelproject.dto.member.MemberDTO;
 import lombok.extern.log4j.Log4j2;
@@ -10,12 +11,16 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import java.lang.reflect.Method;
+
 @Component
 @Log4j2
 public class CustomMemberArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.getParameterType().equals(MemberDTO.class);
+        if(!parameter.getParameterType().equals(MemberDTO.class)) return false;
+        Method method = parameter.getMethod();
+        return method != null && method.isAnnotationPresent(Member.class);
     }
 
     @Override

--- a/src/main/java/com/busanit501/travelproject/interceptor/ReadMemberInterceptor.java
+++ b/src/main/java/com/busanit501/travelproject/interceptor/ReadMemberInterceptor.java
@@ -7,19 +7,15 @@ import com.busanit501.travelproject.dto.util.CookieDTO;
 import com.busanit501.travelproject.service.member.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
+@RequiredArgsConstructor
 public class ReadMemberInterceptor implements HandlerInterceptor {
     private final MemberService memberService;
-
-    @Autowired
-    public ReadMemberInterceptor(MemberService memberService) {
-        this.memberService = memberService;
-    }
 
     @Override
     public boolean preHandle(HttpServletRequest request,


### PR DESCRIPTION
ArgumentResolver가 @Member가 없는 메서드의 MemberDTO 파라미터에 값을 넣는 오류 수정 완료.