### PR TITLE
이미지 섬네일 기능 추가

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,18 @@ logging.config=classpath:logback-spring.xml
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
+
+# Multipart 업로드 시 파일이 임시로 저장될 폴더
+spring.servlet.multipart.location=${user.home}/.Travel/uploads
+
+# 이미지 파일을 최종적으로 저장할 곳
+# 서버 관리자가 이 위치에 폴더를 만들어야 함
+com.busanit501.travelproject.upload.path=${user.home}/.Travel/uploads
+
+# 이미지 섬네일을 저장하는 곳
+# 서버 관리자가 이 위치에 폴더를 만들어야 함
+com.busanit501.travelproject.thumbnail.path=${user.home}/.Travel/thumbnails
+
+# 파일 업로드 크기 제한 완화
+spring.servlet.multipart.max-file-size=20MB
+spring.servlet.multipart.max-request-size=100MB

--- a/src/main/resources/templates/admin/images_jh1.html
+++ b/src/main/resources/templates/admin/images_jh1.html
@@ -82,7 +82,7 @@
           _el('h3', product.productName),
           _el('div', product.imagePath, div => div.classList.add('text-body-secondary')),
           _el('img', img => {
-            img.src = '/productImage/' + product.imagePath
+            img.src = '/thumbnail/' + product.imagePath
             img.alt = product.imagePath
           }),
           a => {
@@ -100,7 +100,7 @@
         _el('a',
           _el('div', unusedImage),
           _el('img', img => {
-            img.src = '/productImage/' + unusedImage
+            img.src = '/thumbnail/' + unusedImage
             img.alt = unusedImage
           }),
           a => {

--- a/src/test/java/com/busanit501/travelproject/service/Jh1ServiceTest.java
+++ b/src/test/java/com/busanit501/travelproject/service/Jh1ServiceTest.java
@@ -1,7 +1,7 @@
 package com.busanit501.travelproject.service;
 
 import com.busanit501.travelproject.dto.FreeBoardJh1DTO;
-import com.busanit501.travelproject.dto.LocationValueJh1DTO;
+import com.busanit501.travelproject.dto.ProductImageAdminDTO;
 import com.busanit501.travelproject.dto.util.PageRequestJh1DTO;
 import com.busanit501.travelproject.dto.util.PageResponseJh1DTO;
 import com.busanit501.travelproject.service.admin.AdminJh1Service;
@@ -18,6 +18,9 @@ public class Jh1ServiceTest {
 
   @Autowired
   private AdminJh1Service service;
+
+  @Autowired
+  private UploadedImagesComponent imageWalker;
 
 //  @Test
 //  public void registerLocationTest() {
@@ -61,5 +64,17 @@ public class Jh1ServiceTest {
     PageResponseJh1DTO<FreeBoardJh1DTO> freeBoardList = service.getFreeBoardList(PageRequestJh1DTO.builder().page(1).size(10).build());
     log.info("freeBoardList : {}", freeBoardList);
     freeBoardList.getDtoList().forEach(log::info);
+  }
+
+  @Test
+  public void imagesTest() {
+    List<ProductImageAdminDTO> list = service.getProductImages();
+    list.forEach(log::info);
+  }
+
+  @Test
+  public void imageDirTest() {
+    List<String> list = imageWalker.getList();
+    list.forEach(log::info);
   }
 }


### PR DESCRIPTION
# 변경사항

- **관리자가 이미지를 업로드할 때 섬네일이 함께 생성됩니다.**

이미지 URL은 `localhost:8080/productImage/{imagePath}`, 섬네일 URL은 `localhost:8080/thumbnail/{imagePath}`입니다. `{imagePath}`는 Product 엔티티에 들어가는 그 문자열 그대로 들어갑니다.

````javascript
const productDTO = /*[[${productDTO}]]*/ {};  // thymeleaf, REST 둘다 가능
const img = document.querySelector('img');
img.src = '/productImage/' + productDTO.imagePath;

const thumb = document.querySelector('img.thumbnail');
thumb.src = '/thumbnail/' + productDTO.imagePath;
````

- **이미지 경로의 제한이 없어졌습니다.**

````
localhost:8080/productImage/country/japan/osaka.jpg
````

# ⚠중요

드디어 `application.properties` 파일을 수정했습니다. 스프링의 기본 파일 크기 제한이 생각보다 작기 때문에, 이 제한도 풀어야 했습니다.

`application.properties`에 지정된 다음 두 위치에 폴더를 만들어야 합니다. 이 폴더의 하위 폴더는 컨트롤러에서 자동 생성합니다.


````
# 이미지 파일을 최종적으로 저장할 곳
# 서버 관리자가 이 위치에 폴더를 만들어야 함
com.busanit501.travelproject.upload.path=${user.home}/.Travel/uploads

# 이미지 섬네일을 저장하는 곳
# 서버 관리자가 이 위치에 폴더를 만들어야 함
com.busanit501.travelproject.thumbnail.path=${user.home}/.Travel/thumbnails
````

> 스프링 컨트롤러가 하드디스크 상에서 폴더 위치를 잘 기억하기 때문에 여행사이트 고객 사용자 및 Admin은 이 위치를 외울 필요가 없습니다. 고객 및 사용자는 `localhost:8080/productImage/{imagePath}` 및 `localhost:8080/thumbnail/{imagePath}`만 알고 있으면 됩니다.

# 중요2

이미 업로드된 이미지 파일의 섬네일을 따는 작업은 따로 진행되지 않습니다..


