### PR TITLE
하청빈-middle pr

### DIFF
--- a/src/main/java/com/busanit501/travelproject/controller/reservation/ReservationRestController.java
+++ b/src/main/java/com/busanit501/travelproject/controller/reservation/ReservationRestController.java
@@ -4,6 +4,7 @@ import com.busanit501.travelproject.annotation.member.Member;
 import com.busanit501.travelproject.domain.common.ReservationOrder;
 import com.busanit501.travelproject.dto.ProductJh1DTO;
 import com.busanit501.travelproject.dto.member.MemberDTO;
+import com.busanit501.travelproject.dto.reservation.RefundDTO;
 import com.busanit501.travelproject.dto.reservation.ReservationDTO;
 import com.busanit501.travelproject.dto.reservation.ReservationUserDTO;
 import com.busanit501.travelproject.dto.util.reservationPageDTO.HcbPageRequestDTO;
@@ -74,9 +75,10 @@ public class ReservationRestController {
         return Map.of("reservationNo", result);
     }
 
-    @PutMapping("/refund/{reservationNo}")
-    public Map<String, Boolean> refund(@PathVariable Long reservationNo) {
-        boolean result = reservationService.refundReservation(reservationNo);
+    @PostMapping("/refund")
+    public Map<String, Boolean> refund(@RequestBody RefundDTO refundDTO) {
+        log.info(refundDTO + "들어오는 refundDTO 확인");
+        boolean result = reservationService.refundReservation(refundDTO.getReservationNo(),refundDTO.getRefundPercent());
         return Map.of("reservationNo", result);
     }
 

--- a/src/main/java/com/busanit501/travelproject/controller/reservation/ReservationRestController.java
+++ b/src/main/java/com/busanit501/travelproject/controller/reservation/ReservationRestController.java
@@ -45,7 +45,7 @@ public class ReservationRestController {
 
     @PostMapping("/reg")
     @Member
-    public Map<String, Long> reg(
+    public boolean reg(
             @Valid @RequestBody ReservationDTO reservationDTO, BindingResult bindingResult,
             MemberDTO memberDTO) throws BindException {
         if (bindingResult.hasErrors()) {
@@ -55,8 +55,8 @@ public class ReservationRestController {
             throw new BindException(bindingResult);
         }
         reservationDTO.setMemberNo(memberDTO.getMemberNo());
-        Long result = reservationService.registerReservation(reservationDTO);
-        return Map.of("reservationNo", result);
+        Boolean result = reservationService.registerReservation(reservationDTO);
+        return result;
     }
 
     @PutMapping("/edit")

--- a/src/main/java/com/busanit501/travelproject/dto/reservation/RefundDTO.java
+++ b/src/main/java/com/busanit501/travelproject/dto/reservation/RefundDTO.java
@@ -1,0 +1,13 @@
+package com.busanit501.travelproject.dto.reservation;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class RefundDTO {
+    private Long reservationNo;
+    private int refundPercent;
+}

--- a/src/main/java/com/busanit501/travelproject/service/reservation/ReservationService.java
+++ b/src/main/java/com/busanit501/travelproject/service/reservation/ReservationService.java
@@ -18,7 +18,7 @@ public interface ReservationService {
     Long registerReservation(ReservationDTO reservationDTO);
     Long updateReservation(ReservationDTO reservationDTO);
     Long deleteReservation(Long reservationNo);
-    boolean refundReservation(Long reservationNo);
+    boolean refundReservation(Long reservationNo, int refundPercent);
     Long deleteReservationNow(Long reservationNo);
     HcbPageResponseDTO<ReservationUserDTO> getReservationUser(Long memberNo, ReservationOrder reservationOrder, HcbPageRequestDTO hcbPageRequestDTO);
     HcbPageResponseDTO<ReservationDTO> getReservationAdmin(Long productNo, HcbPageRequestDTO hcbPageRequestDTO);

--- a/src/main/java/com/busanit501/travelproject/service/reservation/ReservationService.java
+++ b/src/main/java/com/busanit501/travelproject/service/reservation/ReservationService.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 
 public interface ReservationService {
-    Long registerReservation(ReservationDTO reservationDTO);
+    Boolean registerReservation(ReservationDTO reservationDTO);
     Long updateReservation(ReservationDTO reservationDTO);
     Long deleteReservation(Long reservationNo);
     boolean refundReservation(Long reservationNo, int refundPercent);

--- a/src/main/java/com/busanit501/travelproject/service/reservation/ReservationServiceImpl.java
+++ b/src/main/java/com/busanit501/travelproject/service/reservation/ReservationServiceImpl.java
@@ -43,14 +43,17 @@ public class ReservationServiceImpl implements ReservationService {
     private final CustomMapperJh1 customMapper;
 
     @Override
-    public Long registerReservation(ReservationDTO reservationDTO) {
-        Reservation reservation = Reservation.builder()
-                .member(memberRepository.findByMemberNo(reservationDTO.getMemberNo()))
-                .product(productJh1Repository.findProductByProductNo(reservationDTO.getProductNo()).orElseThrow())
-                .reservationOrder(reservationDTO.getReservationOrder())
-                .build();
-        Reservation result = reservationRepository.save(reservation);
-        return result.getReservationNo();
+    public Boolean registerReservation(ReservationDTO reservationDTO) {
+        if(productJh1Repository.findProductByProductNo(reservationDTO.getProductNo()).isEmpty()) {
+            Reservation reservation = Reservation.builder()
+                    .member(memberRepository.findByMemberNo(reservationDTO.getMemberNo()))
+                    .product(productJh1Repository.findProductByProductNo(reservationDTO.getProductNo()).orElseThrow())
+                    .reservationOrder(reservationDTO.getReservationOrder())
+                    .build();
+            Reservation result = reservationRepository.save(reservation);
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/busanit501/travelproject/service/reservation/ReservationServiceImpl.java
+++ b/src/main/java/com/busanit501/travelproject/service/reservation/ReservationServiceImpl.java
@@ -75,18 +75,19 @@ public class ReservationServiceImpl implements ReservationService {
 
     @Override
     @Transactional
-    public boolean refundReservation(Long reservationNo) {
+    public boolean refundReservation(Long reservationNo,int refundPercent) {
         Reservation reservation = reservationRepository.findById(reservationNo).orElseThrow();
         Member member = reservation.getMember();
         int memberPoint = reservation.getMember().getMemberPoint();
         int productPrice = reservation.getProduct().getPrice().intValue();
+        int refundPrice = (productPrice*refundPercent/100);
         member.updateMemberData(UpdateDTO.builder()
                 .memberID(member.getMemberID())
                 .memberPassword(member.getMemberPassword())
                 .memberName(member.getMemberName())
                 .memberEmail(member.getMemberEmail())
                 .memberPhone(member.getMemberPhone())
-                .memberPoints(memberPoint + productPrice)
+                .memberPoints(memberPoint + refundPrice)
                 .build());
         memberRepository.save(member);
         reservation.changeOrder(ReservationOrder.CANCELLED);

--- a/src/main/resources/static/script/cart/cart.js
+++ b/src/main/resources/static/script/cart/cart.js
@@ -15,12 +15,12 @@ async function delCart(productNo) {
 
 async function addCart(productNo) {
     const result = await axios.get(`/cart/add/${productNo}`)
-    return result
+    return result.data
 }
 
 async function getImage(imgPath) {
     const result = await axios.get(`/productImage/${imgPath}`)
-    return result
+    return result.data
 }
 
 async function makeReservationImmediately(productNo) {

--- a/src/main/resources/static/script/reservation/reservation.js
+++ b/src/main/resources/static/script/reservation/reservation.js
@@ -12,8 +12,12 @@ async function deleteReservation(reservationNo){
     const result = await axios.put(`/reservation/delete/${reservationNo}`)
     return result.data
 }
-async function refundReservation(reservationNo){
-    const result = await axios.put(`/reservation/refund/${reservationNo}`)
+async function refundReservation(reservationNo,refundPercent){
+    const obj = {
+        reservationNo: `${reservationNo}`,
+        refundPercent: `${refundPercent}`
+    }
+    const result = await axios.post(`/reservation/refund`, obj)
     return result.data
 }
 

--- a/src/main/resources/templates/cart/cartPage.html
+++ b/src/main/resources/templates/cart/cartPage.html
@@ -13,7 +13,7 @@
 <!--    <button type="button" class="btn btn-secondary" onclick="addCart(1)">1 장바구니 추가 (임시)</button>-->
 <!--    <button type="button" class="btn btn-secondary" onclick="addCart(2)">2 장바구니 추가 (임시)</button>-->
 <!--    <button type="button" class="btn btn-secondary" onclick="addCart(3)">3 장바구니 추가 (임시)</button>-->
-<!--    <button type="button" class="btn btn-secondary" onclick="makeReservationImmediately(1,)">1 즉시 예약 (임시)</button>-->
+    <button type="button" class="btn btn-secondary" onclick="makeReservationImmediately(1)">1 즉시 예약 (임시)</button>
 </main>
 
 <div layout:fragment="javascript">

--- a/src/main/resources/templates/member/productDetail.html
+++ b/src/main/resources/templates/member/productDetail.html
@@ -152,15 +152,17 @@
 
         function productAddcart(productNo) {
             addCart(productNo).then(data => {
-                if (data) alert("상품이 성공적으로 담겼습니다");
+                if (data.addResult == "success") alert("여행이 성공적으로 담겼습니다");
+                else if (data.addResult == "alreadyReserved") alert("이미 예약된 여행입니다.")
+                else if (data.addResult == "alreadyCarted") alert("이미 장바구니에 담긴 여행입니다.")
                 else alert("장바구니 담기에 실패했습니다.")
             })
         }
 
         function productAddReservation(productNo) {
             makeReservationImmediately(productNo).then(data => {
-                if (data) alert("상품이 성공적으로 예약되었습니다.");
-                else alert("예약에 실패했습니다.")
+                if (data) alert("여행이 성공적으로 예약되었습니다.");
+                else alert("이미 예약한 여행입니다.")
             })
         }
     </script>

--- a/src/main/resources/templates/member/reservation.html
+++ b/src/main/resources/templates/member/reservation.html
@@ -165,7 +165,7 @@
                                     <div class="d-flex justify-content-end gap-2">
                                         ${reservationOrder !== 'COMPLETED' ? `<button type="button" class="btn btn-primary feePaymentBtn" data-reservationNo="${dto.reservationNo}">결제</button>` : ''}
                                         ${reservationOrder === 'PENDING' ? `<button type="button" class="btn btn-danger reservationDelBtn" data-reservationNo="${dto.reservationNo}">취소</button>` : ''}
-                                        ${reservationOrder === 'COMPLETED' ? `<button type="button" class="btn btn-danger reservationRefBtn" data-reservationNo="${dto.reservationNo}">환불</button>` : ''}
+                                        ${reservationOrder === 'COMPLETED' ? `<button type="button" class="btn btn-danger reservationRefBtn" data-reservationNo="${dto.reservationNo}" data-startDate="${dto.productStartDate}">환불</button>` : ''}
                                     </div>
                                 </div>
                             </div>
@@ -241,32 +241,56 @@
             e.stopPropagation()
             e.preventDefault()
             const reservationNo = target.getAttribute("data-reservationNo")
-            feeReservation(reservationNo).then(data => {
-                    printReservation(reservationOrder, page, size)
-                    printMemberPoint()
-                }
-            ).catch(e => console.error(e))
+            if(confirm("해당 예약을 결제하시겠습니까?")) {
+                feeReservation(reservationNo).then(data => {
+                        if (data.paymentCompCheck) alert("예약되었습니다.")
+                        else alert("잔여포인트가 부족합니다.")
+                        printReservation(reservationOrder, page, size)
+                        printMemberPoint()
+                    }
+                ).catch(e => console.error(e))
+            }
         })
 
         document.querySelector(".reservationList").addEventListener("click", function (e) {
             const target = e.target
             if (!target.classList.contains('reservationDelBtn')) return
             const reservationNo = target.getAttribute("data-reservationNo")
-            deleteReservation(reservationNo).then(data =>
-                printReservation(reservationOrder, page, size)
-            ).catch(e => console.error(e))
-
+            if(confirm("해당 예약을 취소하시겠습니까?")) {
+                deleteReservation(reservationNo).then(data =>
+                    printReservation(reservationOrder, page, size)
+                ).catch(e => console.error(e))
+            }
         })
 
         document.querySelector(".reservationList").addEventListener("click", function (e) {
             const target = e.target
             if (!target.classList.contains('reservationRefBtn')) return
             const reservationNo = target.getAttribute("data-reservationNo")
-            refundReservation(reservationNo).then(data => {
-                printReservation(reservationOrder, page, size)
-                printMemberPoint()
-            }).catch(e => console.error(e))
-
+            const diffDateFormula = Math.floor((new Date(target.getAttribute("data-startDate")) - new Date())/(1000*60*60*24))
+            const diffDate = diffDateFormula < 0 ? 0 : diffDateFormula
+            let refundPercent
+            switch (diffDate) {
+                default : refundPercent = 100; break
+                case 9:
+                case 8: refundPercent = 95;break
+                case 7:
+                case 6:
+                case 5:
+                case 4:
+                case 3:
+                case 2: refundPercent = 90;break
+                case 1: refundPercent = 80;break
+                case 0: refundPercent = 50;break
+            }
+            if(confirm(`규정에 따라 ${refundPercent}%의 포인트가 환불됩니다. \n 해당 예약을 환불하시겠습니까?`)) {
+                refundReservation(reservationNo,refundPercent).then(data => {
+                    if (data) alert("환불되었습니다.")
+                    else alert("")
+                    printReservation(reservationOrder, page, size)
+                    printMemberPoint()
+                }).catch(e => console.error(e))
+            }
         })
 
         function setImagePath(imagePath) {


### PR DESCRIPTION
reservation 페이지에서 결제, 환불, 취소 확인 추가, 남은 날짜에 비해 환불 비율 정하는 로직 구현, 여행 상세페이지에서 같은 상품은 예약 못하게 service 단에서 구분하여 return 한 것을 각각 즉시예약과 장바구니 추가에서 거를 수 있게 작업, 대신 만약 장바구니에 이미 예약한 여행을 예약하는 경우 아예 예약이 안되게 작업 확인 필요